### PR TITLE
Give Item Command

### DIFF
--- a/examples/02_killing_spree.py
+++ b/examples/02_killing_spree.py
@@ -30,14 +30,13 @@ class KillingSpree(Scenario):
     def on_tick(self, agents) -> None:
 
         # Agent actions
-        closest_villager = agents['computer'].state.get_entity_by_type(Mob.villager)
+        closest_villager = agents['computer'].state.get_nearby_entity(Mob.villager)
         if closest_villager is not None:
             agents['computer'].attack(closest_villager)
         else:
             agents['computer'].do_nothing()
 
         
-
 
 
 # Run scenario

--- a/examples/03_gather_food.py
+++ b/examples/03_gather_food.py
@@ -1,0 +1,54 @@
+from malmoext import Scenario, Vector, Block, Item, Inventory
+
+class GatherFood(Scenario):
+    '''Scenario where a computer agent gathers food items from the ground and returns them to a human player.
+    The food items are strategically placed on the ground at the start of the scenario.'''
+
+    def build_scenario(self, builder):
+        
+        # Metadata
+        builder.set_description('Gather Food')
+        builder.set_time_limit(30)
+
+        # Agents (computer agent starts with 4 baked potatoes in their inventory, spread across two inventory slots)
+        builder.add_agent('computer')
+        builder.agents['computer'].set_position(Vector(0, 4, 0))
+        builder.agents['computer'].add_inventory_item(Item.baked_potato, Inventory.HotBar._1, 1)
+        builder.agents['computer'].add_inventory_item(Item.baked_potato, Inventory.HotBar._2, 3)
+
+        builder.add_agent('human')
+        builder.agents['human'].set_position(Vector(8, 4, 8))
+
+        # Structures
+        builder.world.add_line(Block.fence, Vector(-30, 4, -30), Vector(30, 4, -30))
+        builder.world.add_line(Block.fence, Vector(30, 4, -30), Vector(30, 4, 30))
+        builder.world.add_line(Block.fence, Vector(30, 4, 30), Vector(-30, 4, 30))
+        builder.world.add_line(Block.fence, Vector(-30, 4, 30), Vector(-30, 4, -30))
+
+        # Items
+        builder.world.add_item(Item.baked_potato, Vector(-8, 4, -8))
+        builder.world.add_item(Item.baked_potato, Vector(-8, 4, 8))
+        builder.world.add_item(Item.baked_potato, Vector(8, 4, -8))
+
+
+
+    def on_tick(self, agents) -> None:
+
+        if agents['computer'].state.has_inventory_item(Item.baked_potato):
+            # Agent has food. Give it to the human player.
+            # Pause momentarily to give the human time to pick it up.
+            agents['computer'].give_item(Item.baked_potato, 'human')
+
+        elif agents['computer'].state.has_nearby_entity(Item.baked_potato):
+            # Food is lying nearby. Go and pick it up.
+            agents['computer'].move_to(Item.baked_potato)
+
+        else:
+            # Nothing to do
+            agents['computer'].do_nothing()
+
+        
+
+
+# Run scenario
+scenario = GatherFood().run(ports=[10000, 10001])

--- a/examples/03_gather_food.py
+++ b/examples/03_gather_food.py
@@ -26,9 +26,10 @@ class GatherFood(Scenario):
         builder.world.add_line(Block.fence, Vector(-30, 4, 30), Vector(-30, 4, -30))
 
         # Items
-        builder.world.add_item(Item.baked_potato, Vector(-8, 4, -8))
-        builder.world.add_item(Item.baked_potato, Vector(-8, 4, 8))
-        builder.world.add_item(Item.baked_potato, Vector(8, 4, -8))
+        # builder.world.add_item(Item.baked_potato, Vector(-8, 6, -8))
+        # builder.world.add_item(Item.baked_potato, Vector(-8, 6, 8))
+        # builder.world.add_item(Item.baked_potato, Vector(8, 6, -8))
+        # builder.world.add_item(Item.diamond, Vector(8, 8, -8))
 
 
 
@@ -36,18 +37,18 @@ class GatherFood(Scenario):
 
         if agents['computer'].state.has_inventory_item(Item.baked_potato):
             # Agent has food. Give it to the human player.
-            # Pause momentarily to give the human time to pick it up.
             agents['computer'].give_item(Item.baked_potato, 'human')
 
         elif agents['computer'].state.has_nearby_entity(Item.baked_potato):
             # Food is lying nearby. Go and pick it up.
+            agents['computer'].look_at(Item.baked_potato)
             agents['computer'].move_to(Item.baked_potato)
 
         else:
             # Nothing to do
             agents['computer'].do_nothing()
 
-        
+
 
 
 # Run scenario

--- a/examples/03_gather_food.py
+++ b/examples/03_gather_food.py
@@ -26,10 +26,9 @@ class GatherFood(Scenario):
         builder.world.add_line(Block.fence, Vector(-30, 4, 30), Vector(-30, 4, -30))
 
         # Items
-        # builder.world.add_item(Item.baked_potato, Vector(-8, 6, -8))
-        # builder.world.add_item(Item.baked_potato, Vector(-8, 6, 8))
-        # builder.world.add_item(Item.baked_potato, Vector(8, 6, -8))
-        # builder.world.add_item(Item.diamond, Vector(8, 8, -8))
+        builder.world.add_item(Item.baked_potato, Vector(-8, 6, -8))
+        builder.world.add_item(Item.baked_potato, Vector(-8, 6, 8))
+        builder.world.add_item(Item.baked_potato, Vector(8, 6, -8))
 
 
 

--- a/src/malmoext/agent.py
+++ b/src/malmoext/agent.py
@@ -3,7 +3,6 @@ from typing import Union
 from malmoext.scenario_builder import AgentBuilder
 from malmoext.types import Mob, Item, Inventory, Entity, Vector, Rotation
 from malmoext.utils import Utils
-from enum import Enum
 import math
 
 class Agent:
@@ -17,13 +16,20 @@ class Agent:
     ATTACK_KEEP_DISTANCE = 3
     '''Distance tolerance (in number of blocks) when attacking an entity'''
 
+    GIVE_KEEP_DISTANCE = 4
+    '''Distance tolerance (in number of blocks) when giving an item to an entity'''
+
+    TRADE_IGNORE_TIME = 10
+    '''Number of clock ticks an agent will ignore recently traded items for'''
+
 
     def __init__(self, builder: AgentBuilder):
         '''Constructor'''
         self.__name = builder.get_name()
         self.__observable_distances = builder.get_observable_distances()
         self.__host = MalmoPython.AgentHost()
-        self.state = None   # type: AgentState
+        self.__recent_trade_positions = {}        # type: dict[Vector, int]
+        self.state = None                         # type: AgentState
 
 
     def get_name(self):
@@ -39,25 +45,11 @@ class Agent:
     def get_host(self):
         '''Returns a reference to the Malmo AgentHost connection to the Minecraft server'''
         return self.__host
-    
+
 
     def is_mission_active(self) -> bool:
         '''Returns true if this agent's mission is still active. Returns false otherwise.'''
         return self.__host.peekWorldState().is_mission_running
-    
-
-    def sync(self):
-        '''Syncs the data cached on this agent with the latest available data from the Malmo Minecraft server. Returns
-        true if new data has been loaded. Returns false otherwise.
-        
-        This method does not need to be called explicitly by users of this library, as it is called automatically during
-        simulation of a scenario.'''
-
-        if self.__host.peekWorldState().number_of_observations_since_last_state > 0:
-            self.state = AgentState(self)
-            return True
-
-        return False
 
 
     def do_nothing(self):
@@ -96,7 +88,7 @@ class Agent:
         return True
 
 
-    def look_at(self, entity: Union[str, Mob, Entity]):
+    def look_at(self, entity: Union[str, Mob, Item, Entity]) -> bool:
         '''Initiates camera movement of this agent's POV to face another entity, specified either by name or by reference.
         If multiple entities exist with the given name, the closest one will be targeted.
         
@@ -128,10 +120,10 @@ class Agent:
         return Utils.equal_tol(turn_rates.yaw, 0, 0.05) and Utils.equal_tol(turn_rates.pitch, 0, 0.05)
     
 
-    def move_to(self, entity: Union[str, Mob, Entity], keep_distance = 2):
+    def move_to(self, entity: Union[str, Mob, Item, Entity], keep_distance = 1) -> bool:
         '''Initiates movement of this agent to another entity, specified either by name or by reference. If multiple
         entities exist with the given name, the closest one will be targeted. Optionally specify a number of blocks the
-        agent should keep away from the target (defaults to 2, since two entities cannot occupy the same block). This
+        agent should keep away from the target (defaults to 1, since two entities cannot occupy the same block). This
         can be useful in cases where the agent plans to attack or give an item to the target.
         
         Because this transition does not occur instantaneously, this method is inteded to be called repeatedly as part
@@ -164,7 +156,7 @@ class Agent:
         return is_at
     
 
-    def attack(self, entity: Union[str, Mob, Entity]):
+    def attack(self, entity: Union[str, Mob, Entity]) -> bool:
         '''Initiates an attack against another entity, specified either by name or by reference. If multiple entities
         exist with the given name, the closest one will be targeted. The attack will be performed using the currently-equipped
         item.
@@ -190,17 +182,69 @@ class Agent:
         return True
         
 
-    def __resolve_entity(self, entity: Union[str, Entity]):
+    def give_item(self, item: Item, entity: Union[str, Mob, Entity]) -> bool:
+        '''Gives an item to another entity, specified either by name or by reference. If multiple entities exist with the given
+        name, the closest one will be targeted.
+        
+        If the agent is not currently looking or located at the target, or does not have the item equipped, this method will
+        default to performing those actions first.
+        
+        Returns true if the item(s) were exchanged successfully. Returns false otherwise.'''
+
+        target = self.__resolve_entity(entity)
+        if target is None:
+            return False
+        
+        # Ensure we are first looking and located at the entity
+        looking_at = self.look_at(entity)
+        located_at = self.move_to(entity, Agent.GIVE_KEEP_DISTANCE)
+        if not looking_at or not located_at:
+            return False
+
+        # Ensure the item is equipped        
+        if not self.equip(item):
+            return False
+        
+        self.__host.sendCommand('discardCurrentItem')
+        print("THREW ITEM ========================================")
+        return True
+
+
+    def _sync(self):
+        '''Syncs the data cached on this agent with the latest available data from the Malmo Minecraft server. Returns
+        true if new data has been loaded. Returns false otherwise.
+        
+        This method is not intended to be called directly by users of this library.'''
+
+        # Update agent state
+        if self.__host.peekWorldState().number_of_observations_since_last_state > 0:
+            self.state = AgentState(self)
+            return True
+
+        # Decrement timers for recent trades
+        self.__recent_trade_targets = {key:(val - 1) for key, val in
+                self.__recent_trade_targets.items() if val > 1}
+
+        return False
+    
+
+    def _get_recent_trade_positions(self):
+        '''Returns the set of positions where this agent has recently traded items.
+        
+        This method is not intended to be called directly by users of this library.'''
+
+        return set(self.__recent_trade_positions.keys())
+
+
+    def __resolve_entity(self, entity: Union[str, Mob, Item, Entity]):
         '''If given the name of an entity, this method will return the closest entity to the agent containing that name (or None if
         no entity with that name could be located). If given an entity reference, this method will return that reference as-is.'''
         
         target = entity
-        if isinstance(target, Enum):
-            target = target.value
-        if isinstance(target, str):
-            target = self.state.get_entity_by_name(target)
-
-        return target
+        if isinstance(target, Entity):
+            return target
+        
+        return self.state.get_nearby_entity(target)
 
     
     def __compute_turn_rates(self, target_position: Vector):

--- a/src/malmoext/agent.py
+++ b/src/malmoext/agent.py
@@ -19,7 +19,10 @@ class Agent:
     GIVE_KEEP_DISTANCE = 4
     '''Distance tolerance (in number of blocks) when giving an item to an entity'''
 
-    TRADE_IGNORE_TIME = 10
+    TRADE_IGNORE_DISTANCE = 3
+    '''Distance (in number of blocks) from recent trade positions that items will be ignored'''
+
+    TRADE_IGNORE_TIME = 70
     '''Number of clock ticks an agent will ignore recently traded items for'''
 
 
@@ -205,8 +208,8 @@ class Agent:
         if not self.equip(item):
             return False
         
+        self.__recent_trade_positions[target.position] = Agent.TRADE_IGNORE_TIME
         self.__host.sendCommand('discardCurrentItem')
-        print("THREW ITEM ========================================")
         return True
 
 
@@ -216,14 +219,14 @@ class Agent:
         
         This method is not intended to be called directly by users of this library.'''
 
+        # Decrement timers for recent trade positions
+        self.__recent_trade_positions = {key:(val - 1) for key, val in
+                self.__recent_trade_positions.items() if val > 1}
+
         # Update agent state
         if self.__host.peekWorldState().number_of_observations_since_last_state > 0:
             self.state = AgentState(self)
             return True
-
-        # Decrement timers for recent trades
-        self.__recent_trade_targets = {key:(val - 1) for key, val in
-                self.__recent_trade_targets.items() if val > 1}
 
         return False
     

--- a/src/malmoext/agent_state.py
+++ b/src/malmoext/agent_state.py
@@ -21,6 +21,7 @@ class AgentState:
         self.__nearby_entities = self.__parse_nearby_entities(raw_data)
         self.__inventory = self.__parse_inventory(raw_data)
         self.__equipped_slot = self.__parse_equipped_slot(raw_data)
+        self.__recent_trade_positions = agent._get_recent_trade_positions()
 
 
     def get_position(self):
@@ -33,27 +34,50 @@ class AgentState:
         return self.__pov
 
 
-    def get_entities(self):
+    def has_nearby_entity(self, aType: Union[Mob, Item]):
+        '''Returns true if an entity with the given type exists within the agent's observable range.
+        Returns false otherwise.'''
+
+        return self.__get_entity_by_type(aType) is not None
+
+
+    def get_nearby_entities(self):
         '''Returns a dictionary containing all entities nearby the agent, organized by type.'''
+        
         return self.__nearby_entities
     
     
-    def get_entities(self, mob_type: Mob):
-        '''Returns a list containing all nearby entities of the given mob type.'''
+    def get_nearby_entities(self, aType: Union[Mob, Item]):
+        '''Returns a list containing all nearby entities of the given type.'''
         
-        if mob_type not in self.__nearby_entities:
+        if aType not in self.__nearby_entities:
             return []
         
-        return self.__nearby_entities[mob_type]
+        return self.__nearby_entities[aType]
 
 
-    def get_entity_by_type(self, mob_type: Mob):
-        '''Returns the closest entity to the agent containing the given type. Returns None if no entity with that
+    def get_nearby_entity(self, aType: Union[Mob, Item, str]):
+        '''Returns the closest entity to the agent, specified either by name or by type. Ignores any items that
+        have been recently given to another entity. Returns None if no entity could be found using the information
+        provided.'''
+
+        if isinstance(aType, str):
+            return self.__get_entity_by_name(aType)
+        else:
+            return self.__get_entity_by_type(aType)
+
+    
+    def __get_entity_by_type(self, mob_type: Union[Mob, Item]):
+        '''Returns the closest entity to the agent containing the given type. Ignores any items that
+        have been recently given to another entity. Returns None if no entity with that
         type exists within the agent's observable range.'''
 
         if mob_type not in self.__nearby_entities:
             return None
         
+        # Ignore items near positions we've recently traded at
+        ignore_positions = self._
+
         closest_sqrd_distance = None
         closest_entity = None
         for entity in self.__nearby_entities[mob_type]:
@@ -63,11 +87,12 @@ class AgentState:
                 closest_entity = entity
         
         return closest_entity
+    
 
-
-    def get_entity_by_name(self, name: str):
-        '''Returns the closest entity to the agent containing the given name. Returns None if no entity with that
-        name exists within the agent's observable range.'''
+    def __get_entity_by_name(self, name: str):
+        '''Returns the closest entity to the agent containing the given name. Ignores any items that
+        have been recently given to another entity. Returns None if no entity with that name exists
+        within the agent's observable range.'''
 
         closest_sqrd_distance = None
         closest_entity = None
@@ -95,6 +120,12 @@ class AgentState:
         of the agent.'''
 
         return self.__grid[rel_pos]
+
+
+    def has_inventory_item(self, item_type: Item):
+        '''Returns true if the given item exists in the agent's inventory. Returns false otherwise.'''
+
+        return item_type in self.__inventory
 
 
     def get_inventory_item(self, item_type: Item):
@@ -225,4 +256,13 @@ class AgentState:
     def __parse_equipped_slot(self, raw_data: Any):
         '''Parses a raw observation object to determine the currently equipped inventory slot of the agent.'''
 
-        return raw_data['currentItemIndex']
+        index = raw_data['currentItemIndex']
+
+        if Inventory.HotBar.contains(index):
+            return Inventory.HotBar(index)
+        
+        elif Inventory.Main.contains(index):
+            return Inventory.Main(index)
+        
+        else:
+            return Inventory.Armor(index)

--- a/src/malmoext/agent_state.py
+++ b/src/malmoext/agent_state.py
@@ -8,7 +8,6 @@ class AgentState:
     '''An AgentState represents the observable world from the perspective of a single agent.
     It represents an alternative representation of the JSON data provided by Malmo.'''
 
-
     def __init__(self, agent: Agent):
         '''Constructor. Accepts the agent whose perspective this state represents.'''
         
@@ -74,13 +73,13 @@ class AgentState:
 
         if mob_type not in self.__nearby_entities:
             return None
-        
-        # Ignore items near positions we've recently traded at
-        ignore_positions = self._
 
         closest_sqrd_distance = None
         closest_entity = None
         for entity in self.__nearby_entities[mob_type]:
+            if self.__is_item_near_recent_trade(entity):
+                continue
+
             sqrd_distance = Utils.squared_distance(self.__position, entity.position)
             if (closest_entity is None) or (sqrd_distance < closest_sqrd_distance):
                 closest_sqrd_distance = sqrd_distance
@@ -98,6 +97,9 @@ class AgentState:
         closest_entity = None
         for eType in self.__nearby_entities:
             for entity in self.__nearby_entities[eType]:
+                if self.__is_item_near_recent_trade(entity):
+                    continue
+
                 if entity.name == name:
                     sqrd_distance = Utils.squared_distance(self.__position, entity.position)
                     if (closest_entity is None) or (sqrd_distance < closest_sqrd_distance):
@@ -105,6 +107,21 @@ class AgentState:
                         closest_entity = entity
         
         return closest_entity
+
+
+    def __is_item_near_recent_trade(self, entity: Entity):
+        '''Returns true if the given entity is a drop item that exists nearby a position where the agent
+        recently performed a trade. Returns false otherwise.'''
+
+        if not Item.contains(entity.type):
+            return False
+
+        for pos in self.__recent_trade_positions:
+            distance = Utils.distance(entity.position, pos)
+            if distance < Agent.TRADE_IGNORE_DISTANCE:
+                return True
+
+        return False
 
 
     def get_nearby_block(self, rel_pos: Vector):

--- a/src/malmoext/scenario.py
+++ b/src/malmoext/scenario.py
@@ -126,7 +126,7 @@ class Scenario:
 
             # Sync agent states
             for agent in self.__agents.values():
-                agent.sync()
+                agent._sync()
 
             # Call handler to perform agent actions
             self.on_tick(self.__agents)

--- a/src/malmoext/types.py
+++ b/src/malmoext/types.py
@@ -742,4 +742,3 @@ class InventoryItem:
         self.type = iType
         self.quantity = quantity
         self.slot = slot
-

--- a/src/malmoext/types.py
+++ b/src/malmoext/types.py
@@ -715,6 +715,12 @@ class Vector:
         self.y = y
         self.z = z
 
+    def __hash__(self):
+        return hash((self.x, self.y, self.z))
+    
+    def __eq__(self, other):
+        return self.x == other.x and self.y == other.y and self.z == other.z
+
 
 class Rotation:
     '''A rotation in yaw and pitch directions.'''

--- a/src/malmoext/utils.py
+++ b/src/malmoext/utils.py
@@ -11,6 +11,7 @@ class Utils:
     TWO_PI = math.pi * 2
     '''Value of PI times two.'''
 
+
     @staticmethod
     def add_or_append(dictionary: "dict[Any, list[Any]]", key: Any, value: Any):
         '''For a dictionary whose values are lists, this method will attempt to append a value to the list associated
@@ -21,48 +22,72 @@ class Utils:
         else:
             dictionary[key] = [value]
 
+
     @staticmethod
     def equal_tol(value1: float, value2: float, tol: float):
         '''Returns true if the two values are equal, within tolerance. Returns false otherwise.'''
+        
         abs_diff = abs(value1 - value2)
         return abs_diff <= tol
+
 
     @staticmethod
     def linear_map(value, x1, x2, a1, a2):
         '''Linearly maps a value from the range [x1, x2] to the range [a1, a2].'''
+        
         return (value - x1) * (a2 - a1) / (x2 - x1) + a1
+
 
     @staticmethod
     def squared_distance(p1: Vector, p2: Vector):
         '''Returns the squared distance between two points.'''
+        
         return math.pow(p2.x - p1.x, 2) + math.pow(p2.y - p1.y, 2) + math.pow(p2.z - p1.z, 2)
+
 
     @staticmethod
     def distance(p1: Vector, p2: Vector):
         '''Returns the distance between two points.'''
+        
         return math.sqrt(Utils.squared_distance(p1, p2))
+
 
     @staticmethod
     def magnitude(v: Vector):
         '''Computes the magnitude of a vector'''
+        
         return math.sqrt(v.x * v.x + v.y * v.y + v.z * v.z)
+
 
     @staticmethod
     def normalize(v: Vector):
         '''Normalizes a vector, returning the result as a new vector. Returns the zero vector if the given
         vector has magnitude zero'''
+        
         mag = Utils.magnitude(v)
         if Utils.equal_tol(mag, 0, 1.0e-14):
             return Vector(0, 0, 0)
         else:
             return Vector(v.x / mag, v.y / mag, v.z / mag)
         
+
     @staticmethod
     def vector_to(p1: Vector, p2: Vector):
         '''Returns the vector from p1 to p2.'''
+        
         return Vector(p2.x - p1.x, p2.y - p1.y, p2.z - p1.z)
+
 
     @staticmethod
     def is_zero_vector(v: Vector, tol = 0.0):
         '''Returns true if the given vector is the zero vector. An optional tolerance can be specified (defaults to 0).'''
+        
         return Utils.equal_tol(v.x, 0, tol) and Utils.equal_tol(v.y, 0, tol) and Utils.equal_tol(v.z, 0, tol)
+
+
+    @staticmethod
+    def round_vector(v: Vector):
+        '''Rounds the values of the given vector to the nearest whole number values, returning the result as a new
+        vector.'''
+
+        return Vector(round(v.x), round(v.y), round(v.z))


### PR DESCRIPTION
Adds a "give_item" action that enables agents to look at, move to, equip, and give an item to another entity.

Also adds a new example scenario that demonstrates this capability.

Closes #12 